### PR TITLE
[add] #13 Todo削除機能の単体テスト

### DIFF
--- a/src/__tests__/TodoItem.test.tsx
+++ b/src/__tests__/TodoItem.test.tsx
@@ -7,8 +7,15 @@ describe("TodoItem コンポーネント", () => {
   it("タスクのタイトルが正しく表示される", () => {
     const mockTodo = { id: "1", title: "テストタスク", completed: false };
     const mockUpdateTodo = vi.fn();
+    const mockDeleteTodo = vi.fn();
 
-    render(<TodoItem todo={mockTodo} updateTodo={mockUpdateTodo} />);
+    render(
+      <TodoItem
+        todo={mockTodo}
+        updateTodo={mockUpdateTodo}
+        deleteTodo={mockDeleteTodo}
+      />
+    );
 
     const inputElement = screen.getByDisplayValue("テストタスク");
     expect(inputElement).toBeInTheDocument();
@@ -17,8 +24,15 @@ describe("TodoItem コンポーネント", () => {
   it("タイトルを変更してフォーカスを外すと updateTodo が呼び出される", () => {
     const mockTodo = { id: "1", title: "テストタスク", completed: false };
     const mockUpdateTodo = vi.fn();
+    const mockDeleteTodo = vi.fn();
 
-    render(<TodoItem todo={mockTodo} updateTodo={mockUpdateTodo} />);
+    render(
+      <TodoItem
+        todo={mockTodo}
+        updateTodo={mockUpdateTodo}
+        deleteTodo={mockDeleteTodo}
+      />
+    );
 
     const inputElement = screen.getByDisplayValue("テストタスク");
     fireEvent.change(inputElement, { target: { value: "更新されたタスク" } });

--- a/src/__tests__/TodoList.test.tsx
+++ b/src/__tests__/TodoList.test.tsx
@@ -22,3 +22,24 @@ describe("TodoList コンポーネント", () => {
     expect(todoItem).toBeInTheDocument();
   });
 });
+it("タスクを削除するとリストから消える", () => {
+  render(<TodoList />);
+
+  const inputElement = screen.getByPlaceholderText("新しいタスクを追加");
+  const formElement = inputElement.closest("form");
+
+  // タスクを追加
+  fireEvent.change(inputElement, { target: { value: "削除するタスク" } });
+  fireEvent.submit(formElement!);
+
+  // タスクがリストに表示されていることを確認
+  const todoItem = screen.getByDisplayValue("削除するタスク");
+  expect(todoItem).toBeInTheDocument();
+
+  // 削除ボタンをクリック
+  const deleteButton = screen.getByText("Delete");
+  fireEvent.click(deleteButton);
+
+  // タスクがリストから消えていることを確認
+  expect(screen.queryByDisplayValue("削除するタスク")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
TodoItem コンポーネントは、個々のタスクの表示や編集、削除ボタンのクリックイベントを処理する責務を持っているが、削除そのもの（タスクのリストから削除する処理）は親コンポーネントである TodoList に委譲されている。
つまり、TodoItem の削除ボタンは、deleteTodo 関数を呼び出すだけで、実際の削除処理は行わない。
よって削除機能の統合テストは TodoList.test.tsx で行う。