### PR TITLE
[update] #37 Todo追加機能（POST）APIとの連携

### DIFF
--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -19,14 +19,7 @@ export default function TodoList() {
     e.preventDefault(); // フォームのデフォルトの動作を防ぐ
     if (inputValue.trim() === "") return; // 空の入力は無視
 
-    const newTodo = {
-      id: crypto.randomUUID(),
-      title: inputValue,
-      completed: false,
-      flagged: false,
-    };
-
-    addTodo(newTodo);
+    addTodo(inputValue);
     setInputValue(""); // 入力フィールドをクリア
   };
 

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -3,7 +3,7 @@ import type { Todo } from "@/types/todo";
 
 type TodoStore = {
   todos: Todo[];
-  addTodo: (todo: Todo) => void;
+  addTodo: (title: string) => Promise<void>;
   updateTodo: (updatedTodo: Todo) => void;
   deleteTodo: (id: string) => void;
   toggleCompleted: (id: string) => void;
@@ -26,12 +26,25 @@ const saveTodosToSessionStorage = (todos: Todo[]) => {
 export const useTodoStore = create<TodoStore>((set) => ({
   todos: loadTodosFromSessionStorage(),
 
-  addTodo: (todo) =>
-    set((state) => {
-      const updatedTodos = [...state.todos, todo];
-      saveTodosToSessionStorage(updatedTodos);
-      return { todos: updatedTodos };
-    }),
+  addTodo: async (title) => {
+    try {
+      const res = await fetch("http://localhost:3000/api/todos", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title: title }),
+      });
+
+      if (!res.ok) throw new Error("Failed to add todo");
+
+      const newTodo: Todo = await res.json();
+
+      set((state) => ({ todos: [...state.todos, newTodo] }));
+    } catch (error) {
+      console.error("Error adding todo:", error);
+    }
+  },
 
   updateTodo: (updatedTodo) =>
     set((state) => {


### PR DESCRIPTION
# 概要（What & Why）
- Todo追加機能（POST）をAPI経由に切り替え
  - これまでローカル（Zustand + sessionStorage）で追加していた処理を、バックエンドの /api/todos にPOSTリクエストを送る形に変更
   - createdAt などのサーバー生成情報を使うため、クライアント側での生成処理を削除

### store.ts

- `addTodo(todo: Todo)` → `addTodo(title: string)` に変更

- APIリクエスト（fetch）でPOSTするように実装

- POST成功時、返ってきたTodoをZustandのstateに追加

### TodoList.tsx

- `addTodo` 呼び出しを `addTodo(inputValue) `に変更

- new Date() や crypto.randomUUID() の生成を削除